### PR TITLE
Optimize patient search API and fix N+1 query issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     restart: unless-stopped
     volumes:
       - db_data:/var/lib/mysql
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     networks:
       - app_network
 

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,1 @@
+mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root -p${MYSQL_ROOT_PASSWORD} mysql

--- a/src/main/java/lviv/syrovyi/health_care/common/specification/SpecificationCustom.java
+++ b/src/main/java/lviv/syrovyi/health_care/common/specification/SpecificationCustom.java
@@ -20,10 +20,4 @@ public class SpecificationCustom {
                         (r, rq, cb) -> cb.like(cb.lower(r.get(propertyName)), "%" + property.toLowerCase().trim() + "%"))
                 .orElse(null);
     }
-
-    public static Specification<? extends BaseEntity> searchFieldInCollectionOfJoinedIds(String joinField, String field, Set<UUID> set) {
-        return CollectionUtils.isNotEmpty(set) ?
-                (r, rq, cb) -> r.join(joinField).get(field).in(set) :
-                null;
-    }
 }

--- a/src/main/java/lviv/syrovyi/health_care/doctor/controller/dto/response/DoctorOfPatientResponseDTO.java
+++ b/src/main/java/lviv/syrovyi/health_care/doctor/controller/dto/response/DoctorOfPatientResponseDTO.java
@@ -12,5 +12,5 @@ import lombok.NoArgsConstructor;
 public class DoctorOfPatientResponseDTO {
     private String firstName;
     private String lastName;
-    private int totalPatients;
+    private Integer totalPatients;
 }

--- a/src/main/java/lviv/syrovyi/health_care/doctor/repository/DoctorRepository.java
+++ b/src/main/java/lviv/syrovyi/health_care/doctor/repository/DoctorRepository.java
@@ -5,13 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 
-import javax.print.Doc;
 import java.util.List;
 import java.util.UUID;
 
 public interface DoctorRepository extends JpaRepository<Doctor, UUID>, JpaSpecificationExecutor<Doctor> {
-
-    Doctor findByFirstNameAndLastName (String firstName, String lastName);
 
     boolean existsByFirstNameAndLastName (String firstName, String lastName);
 

--- a/src/main/java/lviv/syrovyi/health_care/patient/mapper/PatientMapper.java
+++ b/src/main/java/lviv/syrovyi/health_care/patient/mapper/PatientMapper.java
@@ -12,6 +12,4 @@ public interface PatientMapper {
     Patient mapToEntity (PatientRequestDTO patientRequestDTO);
 
     PatientResponseDTO mapToDTO (Patient patient);
-
-    PatientVisitsResponseDTO mapToVisitsDTO (Patient patient);
 }

--- a/src/main/java/lviv/syrovyi/health_care/patient/repository/PatientRepository.java
+++ b/src/main/java/lviv/syrovyi/health_care/patient/repository/PatientRepository.java
@@ -1,14 +1,16 @@
 package lviv.syrovyi.health_care.patient.repository;
 
 import lviv.syrovyi.health_care.patient.repository.entity.Patient;
+import lviv.syrovyi.health_care.patient.repository.projection.PatientProjection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public interface PatientRepository extends JpaRepository <Patient, UUID>, JpaSpecificationExecutor<Patient> {
@@ -19,7 +21,31 @@ public interface PatientRepository extends JpaRepository <Patient, UUID>, JpaSpe
     @Query("SELECT p.id FROM Patient p")
     List<UUID> findAllPatientIds();
 
-    @Query("SELECT p FROM Patient p LEFT JOIN FETCH p.lastVisits")
-    Page<Patient> findAllPatientsWithVisits(Specification<Patient> spec, Pageable pageable);
-
+    @Query("""
+        SELECT p.id AS id,
+               p.firstName AS firstName,
+               p.lastName AS lastName,
+               v.start, CONVERT_TZ(v.start, 'UTC', d.timezone) AS start,
+               v.end, CONVERT_TZ(v.end, 'UTC', d.timezone) AS end,
+               d.firstName AS doctorFirstName,
+               d.lastName AS doctorLastName,
+               (SELECT COUNT(DISTINCT v2.patient.id) 
+                FROM Visit v2 
+                WHERE v2.doctor.id = d.id) AS totalPatients
+        FROM Patient p
+        LEFT JOIN p.lastVisits v
+        LEFT JOIN v.doctor d
+        WHERE v.start = (
+            SELECT MAX(v2.start)
+            FROM Visit v2
+            WHERE v2.patient.id = p.id AND v2.doctor.id = d.id
+        )
+        AND (:search IS NULL OR p.firstName LIKE %:search%)
+        AND (:doctorIds IS NULL OR d.id IN :doctorIds)
+        """)
+    Page<PatientProjection> findAllPatientsWithLastVisits(
+            @Param("search") String search,
+            @Param("doctorIds") Set<UUID> doctorIds,
+            Pageable pageable
+    );
 }

--- a/src/main/java/lviv/syrovyi/health_care/patient/repository/PatientRepository.java
+++ b/src/main/java/lviv/syrovyi/health_care/patient/repository/PatientRepository.java
@@ -1,6 +1,9 @@
 package lviv.syrovyi.health_care.patient.repository;
 
 import lviv.syrovyi.health_care.patient.repository.entity.Patient;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +18,8 @@ public interface PatientRepository extends JpaRepository <Patient, UUID>, JpaSpe
 
     @Query("SELECT p.id FROM Patient p")
     List<UUID> findAllPatientIds();
+
+    @Query("SELECT p FROM Patient p LEFT JOIN FETCH p.lastVisits")
+    Page<Patient> findAllPatientsWithVisits(Specification<Patient> spec, Pageable pageable);
+
 }

--- a/src/main/java/lviv/syrovyi/health_care/patient/repository/projection/PatientProjection.java
+++ b/src/main/java/lviv/syrovyi/health_care/patient/repository/projection/PatientProjection.java
@@ -1,0 +1,17 @@
+package lviv.syrovyi.health_care.patient.repository.projection;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public interface PatientProjection {
+    UUID getId();
+    String getFirstName();
+    String getLastName();
+    LocalDateTime getStart();
+    LocalDateTime getEnd();
+
+    String getDoctorFirstName();
+    String getDoctorLastName();
+    Integer getTotalPatients();
+}
+

--- a/src/main/java/lviv/syrovyi/health_care/patient/service/impl/PatientServiceImpl.java
+++ b/src/main/java/lviv/syrovyi/health_care/patient/service/impl/PatientServiceImpl.java
@@ -42,7 +42,7 @@ public class PatientServiceImpl implements PatientService {
 
     @Override
     public PatientResponse<PatientVisitsResponseDTO> findAllPatients(PatientFilter patientFilter, Pageable pageable) {
-        Page<Patient> allPatients = patientRepository.findAll(getSearchSpecification(patientFilter), pageable);
+        Page<Patient> allPatients = patientRepository.findAllPatientsWithVisits(getSearchSpecification(patientFilter), pageable);
 
         List<PatientVisitsResponseDTO> collectedDTOs = allPatients
                 .stream()

--- a/src/main/java/lviv/syrovyi/health_care/patient/service/impl/PatientServiceImpl.java
+++ b/src/main/java/lviv/syrovyi/health_care/patient/service/impl/PatientServiceImpl.java
@@ -3,29 +3,24 @@ package lviv.syrovyi.health_care.patient.service.impl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lviv.syrovyi.health_care.patient.controller.dto.response.PatientResponse;
-import lviv.syrovyi.health_care.common.service.timezone.TimezoneService;
 import lviv.syrovyi.health_care.doctor.controller.dto.response.DoctorOfPatientResponseDTO;
-import lviv.syrovyi.health_care.doctor.repository.DoctorRepository;
-import lviv.syrovyi.health_care.doctor.repository.entity.Doctor;
 import lviv.syrovyi.health_care.patient.controller.dto.request.PatientRequestDTO;
 import lviv.syrovyi.health_care.patient.controller.dto.response.PatientResponseDTO;
 import lviv.syrovyi.health_care.patient.controller.dto.response.PatientVisitsResponseDTO;
 import lviv.syrovyi.health_care.patient.mapper.PatientMapper;
 import lviv.syrovyi.health_care.patient.repository.PatientRepository;
 import lviv.syrovyi.health_care.patient.repository.entity.Patient;
+import lviv.syrovyi.health_care.patient.repository.projection.PatientProjection;
 import lviv.syrovyi.health_care.patient.service.PatientService;
 import lviv.syrovyi.health_care.patient.service.filter.PatientFilter;
 import lviv.syrovyi.health_care.visit.controller.dto.response.VisitResponseDTO;
-import lviv.syrovyi.health_care.visit.repository.VisitRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static lviv.syrovyi.health_care.common.specification.SpecificationCustom.*;
 
 @Slf4j
 @Service
@@ -33,34 +28,43 @@ import static lviv.syrovyi.health_care.common.specification.SpecificationCustom.
 public class PatientServiceImpl implements PatientService {
 
     private final PatientRepository patientRepository;
-    private final VisitRepository visitRepository;
-    private final DoctorRepository doctorRepository;
 
     private final PatientMapper patientMapper;
 
-    private final TimezoneService timezoneService;
-
     @Override
     public PatientResponse<PatientVisitsResponseDTO> findAllPatients(PatientFilter patientFilter, Pageable pageable) {
-        Page<Patient> allPatients = patientRepository.findAllPatientsWithVisits(getSearchSpecification(patientFilter), pageable);
+        String search = patientFilter.getSearch();
+        Set<UUID> doctorIds = patientFilter.getDoctorIds();
 
-        List<PatientVisitsResponseDTO> collectedDTOs = allPatients
-                .stream()
-                .map(patient -> {
-                    PatientVisitsResponseDTO patientResponseDTO = patientMapper.mapToVisitsDTO(patient);
+        Page<PatientProjection> allPatients = patientRepository.findAllPatientsWithLastVisits(
+                search,
+                doctorIds,
+                pageable
+        );
 
-                    Map<String, VisitResponseDTO> lastVisitPerDoctor = patientResponseDTO.getLastVisits()
-                            .stream()
-                            .collect(Collectors.toMap(
-                                    visit -> visit.getDoctor().getFirstName() + " " + visit.getDoctor().getLastName(),
-                                    visit -> visit,
-                                    (existing, replacement) -> existing.getStart().isAfter(replacement.getStart()) ? existing : replacement
-                            ));
+        Map<UUID, List<PatientProjection>> patientsGroupedById = allPatients.stream()
+                .collect(Collectors.groupingBy(PatientProjection::getId));
 
-                    List<VisitResponseDTO> lastVisits = getVisits(lastVisitPerDoctor);
+        List<PatientVisitsResponseDTO> collectedDTOs = patientsGroupedById.values().stream()
+                .map(patientProjections -> {
+                    PatientProjection firstPatient = patientProjections.get(0);
+                    List<VisitResponseDTO> visits = patientProjections.stream()
+                            .map(patient -> VisitResponseDTO.builder()
+                                    .start(patient.getStart())
+                                    .end(patient.getEnd())
+                                    .doctor(new DoctorOfPatientResponseDTO(
+                                            patient.getDoctorFirstName(),
+                                            patient.getDoctorLastName(),
+                                            patient.getTotalPatients()
+                                    ))
+                                    .build())
+                            .collect(Collectors.toList());
 
-                    patientResponseDTO.setLastVisits(lastVisits);
-                    return patientResponseDTO;
+                    return PatientVisitsResponseDTO.builder()
+                            .firstName(firstPatient.getFirstName())
+                            .lastName(firstPatient.getLastName())
+                            .lastVisits(visits)
+                            .build();
                 })
                 .collect(Collectors.toList());
 
@@ -69,23 +73,6 @@ public class PatientServiceImpl implements PatientService {
                 .count(allPatients.getTotalElements())
                 .build();
     }
-
-    private List<VisitResponseDTO> getVisits(Map<String, VisitResponseDTO> lastVisitPerDoctor) {
-        List<VisitResponseDTO> lastVisits = new ArrayList<>(lastVisitPerDoctor.values());
-
-        lastVisits.forEach(visit -> {
-            DoctorOfPatientResponseDTO doctorDTO = visit.getDoctor();
-            int totalPatients = visitRepository.countPatientsByDoctorName(doctorDTO.getFirstName(), doctorDTO.getLastName());
-            doctorDTO.setTotalPatients(totalPatients);
-
-            Doctor doctor = doctorRepository.findByFirstNameAndLastName(doctorDTO.getFirstName(), doctorDTO.getLastName());
-
-            visit.setStart(timezoneService.convertToTimezone(visit.getStart(), doctor.getTimezone()));
-            visit.setEnd(timezoneService.convertToTimezone(visit.getEnd(), doctor.getTimezone()));
-        });
-        return lastVisits;
-    }
-
 
     @Override
     public PatientResponseDTO save(PatientRequestDTO patientRequestDTO){
@@ -116,10 +103,5 @@ public class PatientServiceImpl implements PatientService {
 
         Random random = new Random();
         return Optional.of(patientIds.get(random.nextInt(patientIds.size())));
-    }
-
-    private Specification<Patient> getSearchSpecification(PatientFilter patientFilter) {
-        return Specification.where((Specification<Patient>) searchLikeString("lastName", patientFilter.getSearch()))
-                .and((Specification<Patient>) searchFieldInCollectionOfJoinedIds("lastVisits", "doctorId", patientFilter.getDoctorIds()));
     }
 }

--- a/src/main/java/lviv/syrovyi/health_care/visit/controller/dto/request/VisitRequestDTO.java
+++ b/src/main/java/lviv/syrovyi/health_care/visit/controller/dto/request/VisitRequestDTO.java
@@ -1,6 +1,5 @@
 package lviv.syrovyi.health_care.visit.controller.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ server:
   port: 8080
 spring:
   profiles:
-    active: docker
+    active: dev
   application:
     name: "healthCare"
   jpa:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ server:
   port: 8080
 spring:
   profiles:
-    active: dev
+    active: docker
   application:
     name: "healthCare"
   jpa:

--- a/src/main/resources/db/changelog/6-add-index-to-visits.sql
+++ b/src/main/resources/db/changelog/6-add-index-to-visits.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_visits_patient_doctor_start ON visits (patient_id, doctor_id, start_date_time);

--- a/src/main/resources/db/changelog/7-add-index-to-patients.sql
+++ b/src/main/resources/db/changelog/7-add-index-to-patients.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_patients_last_name ON patients (last_name);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -9,3 +9,7 @@ databaseChangeLog:
       file: db/changelog/4-add-unique-doctor-name-constraints.sql
   - include:
       file: db/changelog/5-add-unique-patient-name-constraint.sql
+  - include:
+      file: db/changelog/6-add-index-to-visits.sql
+  - include:
+      file: db/changelog/7-add-index-to-patients.sql


### PR DESCRIPTION
- Refactored `findAllPatients` to use a single JPQL query with dynamic filtering.
- Added support for filtering by `firstName` and `doctorIds` directly in the query.
- Resolved N+1 query issue by fetching last visits for each patient in a single query.
- Removed redundant database calls for `countPatientsByDoctorName` and `findByFirstNameAndLastName`.